### PR TITLE
e - run `tox -v` in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
           pip install pytest
       - name: Test
         run: |
-          tox -e py  # Run tox using the version of Python in `PATH`
+          tox -v -e py  # Run tox using the version of Python in `PATH`


### PR DESCRIPTION
Verbose output can help with diagnosing CI-specific issues.