### PR TITLE
F** remove python 3.6 and 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,6 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
3.7 reached end-of-support on 27 Jun 2023



